### PR TITLE
update api to match docs

### DIFF
--- a/src/FacetList/__tests__/FacetList.test.js
+++ b/src/FacetList/__tests__/FacetList.test.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import FacetList from '../'
+
+const defaultProps = {
+  items: [
+    {value: 'cool label', label: 'cool label', hits: 20},
+    {value: 'another', label: 'another', hits: 10},
+    {value: 'a third', label: 'a third', hits: 4},
+  ],
+  label: 'Cool Facet',
+  name: 'cool-facet',
+  onRemoveSelectedItem: () => {},
+  onSelectItem: () => {},
+}
+
+const wrapEl = renderer => xtend => (
+  renderer(<FacetList {...defaultProps} {...xtend} />)
+)
+
+const mountEl = wrapEl(mount)
+
+const testHandlerArgs = (props, index, cb) => (facet, item) => {
+  expect(typeof facet).toBe('object')
+  expect(facet).toHaveProperty('name')
+  expect(facet.name).toEqual(props.name)
+  expect(facet).toHaveProperty('label')
+  expect(facet.label).toEqual(props.label)
+
+  expect(typeof item).toBe('object')
+  expect(item).toEqual(props.items[index])
+
+  cb()
+}
+
+describe('FacetList', function () {
+  test('passes facet/item objects to onSelectItem', done => {
+    const index = 1
+
+    const onSelectItem = testHandlerArgs(defaultProps, index, done)
+
+    const $el = mountEl({onSelectItem, open: true})
+
+    $el.find('UnsortedFacetList')
+      .findWhere($e => ($e.key() === 'unselected-facets'))
+      .find('.FacetList-item')
+      .at(index)
+      .simulate('click')
+  })
+
+  test('passes facet/item objects to onRemoveSelectedItem', done => {
+    const index = 2
+
+    const onRemoveSelectedItem = testHandlerArgs(defaultProps, index, done)
+
+    const $el = mountEl({
+      items: [],
+      onRemoveSelectedItem,
+      open: true,
+      selectedItems: defaultProps.items,
+    })
+
+    $el.find('UnsortedFacetList')
+      .findWhere($e => ($e.key() === 'selected-facets'))
+      .find('.FacetList-item')
+      .at(index)
+      .simulate('click')
+  })
+})

--- a/src/FacetList/index.js
+++ b/src/FacetList/index.js
@@ -68,6 +68,7 @@ class FacetList extends FacetBase {
   renderLists (limitItems) {
     const {
       items,
+      label,
       limit,
       name,
       selectedItems,
@@ -75,16 +76,18 @@ class FacetList extends FacetBase {
 
     const unselected = limitItems ? items.slice(0, limit) : [].concat(items)
 
+    const facet = { label, name }
+
     return [
       <UnsortedFacetList
-        facet={name}
+        facet={facet}
         items={selectedItems}
         key="selected-facets"
         listClassName="selected"
         onItemClick={this.handleRemoveItem}
       />,
       <UnsortedFacetList
-        facet={name}
+        facet={facet}
         items={unselected}
         key="unselected-facets"
         onItemClick={this.handleSelectItem}

--- a/src/FacetRangeLimitDate/__tests__/create-range-facet-item.test.js
+++ b/src/FacetRangeLimitDate/__tests__/create-range-facet-item.test.js
@@ -1,12 +1,12 @@
-import createRangeFacet from '../create-range-facet'
+import createRangeFacetItem from '../create-range-facet-item'
 
-describe('createRangeFacet', function () {
+describe('createRangeFacetItem', function () {
   test('it produces a range object', () => {
     const name = 'name'
     const min = 1900
     const max = 2000
 
-    const result = createRangeFacet(name, min, max)
+    const result = createRangeFacetItem(name, min, max)
 
     expect(typeof result).toBe('object')
     expect(result).toHaveProperty('label')
@@ -24,14 +24,14 @@ describe('createRangeFacet', function () {
     const min = 1900
     const max = 2000
 
-    const result = createRangeFacet('hi', min, max)
+    const result = createRangeFacetItem('hi', min, max)
     expect(result.label).toContain(min)
     expect(result.label).toContain(max)
   })
 
   test('the label contains a single value if min === max', () => {
     const value = 1000
-    const result = createRangeFacet('same', value, value)
+    const result = createRangeFacetItem('same', value, value)
 
     expect(result.label).toEqual(value.toString())
   })

--- a/src/FacetRangeLimitDate/create-range-facet-item.js
+++ b/src/FacetRangeLimitDate/create-range-facet-item.js
@@ -1,4 +1,4 @@
-export default function createRangeFacet (name, min, max) {
+export default function createRangeFacetItem (name, min, max) {
   const label = min === max ? `${min}` : `${min} - ${max}`
 
   return {

--- a/src/FacetRangeLimitDate/index.js
+++ b/src/FacetRangeLimitDate/index.js
@@ -13,7 +13,7 @@ import {
   VALUES as INTERVAL_VALUES,
 } from './date-intervals'
 
-import createRangeFacet from './create-range-facet'
+import createRangeFacetItem from './create-range-facet-item'
 import calculateRange from './calculate-range'
 import formatDateValue from './format-date-value'
 import roundDate from './round-date-to-interval'
@@ -59,12 +59,13 @@ class FacetRangeLimitDate extends FacetBase {
   }
 
   handleApplyRange (range) {
-    const { interval, name } = this.props
+    const { interval, label, name } = this.props
     const [min, max] = range.map(v => formatDateValue(interval, v))
 
-    const facet = createRangeFacet(name, min, max)
+    const facet = { name, label }
+    const item = createRangeFacetItem(name, min, max)
 
-    this.props.onSelectItem(name, facet)
+    this.props.onSelectItem(facet, item)
   }
 
   maybeRenderSelectedItems () {


### PR DESCRIPTION
the codebase was ported over with select/handlers being passed
a string for the facet property (the facet's `name`). this was
abandoned in favor of an object containing the `name` and `label`
property (useful for creating search breadcrumbs where the `label`
is desired), but not updated in the code.